### PR TITLE
[DISCUSSION] PHP RFC: Objects can be declared falsifiable

### DIFF
--- a/Zend/tests/enum/__toBool.phpt
+++ b/Zend/tests/enum/__toBool.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Enum __toBool
+--FILE--
+<?php
+
+enum Foo {
+    case Bar;
+
+    public function __toBool(): bool {
+        return true;
+    }
+}
+
+?>
+--EXPECTF--
+Fatal error: Enum Foo cannot include magic method __toBool in %s on line %d

--- a/Zend/tests/falsifiable_automatic_implementation.phpt
+++ b/Zend/tests/falsifiable_automatic_implementation.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Falsifiable is automatically implemented
+--FILE--
+<?php
+
+class Test {
+    public function __toBool() {
+        return true;
+    }
+}
+
+var_dump(new Test instanceof Falsifiable);
+var_dump((new ReflectionClass(Test::class))->getInterfaceNames());
+
+class Test2 extends Test {
+    public function __toBool() {
+        return false;
+    }
+}
+
+var_dump(new Test2 instanceof Falsifiable);
+var_dump((new ReflectionClass(Test2::class))->getInterfaceNames());
+
+?>
+--EXPECT--
+bool(true)
+array(1) {
+  [0]=>
+  string(10) "Falsifiable"
+}
+bool(false)
+array(1) {
+  [0]=>
+  string(10) "Falsifiable"
+}

--- a/Zend/tests/falsifiable_internal_class.phpt
+++ b/Zend/tests/falsifiable_internal_class.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Falsifiable should be automatically implemented for internal classes
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+// _ZendTestClass defines __toBool() but does not explicitly implement Falsifiable.
+$obj = new _ZendTestClass;
+var_dump($obj instanceof Falsifiable);
+
+?>
+--EXPECT--
+bool(true)

--- a/Zend/tests/falsifiable_trait.phpt
+++ b/Zend/tests/falsifiable_trait.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Bug #81582: Falsifiable not implicitly declared if __toBool() came from a trait
+--FILE--
+<?php
+
+trait T {
+    public function __toBool(): bool {
+        return true;
+    }
+}
+trait T2 {
+    use T;
+}
+
+class C {
+    use T;
+}
+class C2 {
+    use T2;
+}
+
+var_dump(new C instanceof Falsifiable);
+var_dump(new C2 instanceof Falsifiable);
+
+// The traits themselves should not implement Falsifiable -- traits cannot implement interfaces.
+$rc = new ReflectionClass(T::class);
+var_dump($rc->getInterfaceNames());
+$rc = new ReflectionClass(T2::class);
+var_dump($rc->getInterfaceNames());
+
+?>
+--EXPECT--
+bool(true)
+bool(true)
+array(0) {
+}
+array(0) {
+}

--- a/Zend/tests/falsifiable_trait_invalid.phpt
+++ b/Zend/tests/falsifiable_trait_invalid.phpt
@@ -1,0 +1,14 @@
+--TEST--
+__toBool() from trait with invalid return type
+--FILE--
+<?php
+
+trait T {
+    public function __toBool(): int {
+        return true;
+    }
+}
+
+?>
+--EXPECTF--
+Fatal error: T::__toBool(): Return type must be bool when declared in %s on line %d

--- a/Zend/tests/return_types/045.phpt
+++ b/Zend/tests/return_types/045.phpt
@@ -1,0 +1,11 @@
+--TEST--
+__toBool can only declare bool return type
+--FILE--
+<?php
+class Foo {
+    public function __toBool(): string {
+    }
+}
+?>
+--EXPECTF--
+Fatal error: Foo::__toBool(): Return type must be bool when declared in %s on line %d

--- a/Zend/tests/return_types/never_tobool.phpt
+++ b/Zend/tests/return_types/never_tobool.phpt
@@ -1,0 +1,28 @@
+--TEST--
+never type of __toString method
+--FILE--
+<?php
+
+class A implements Stringable {
+    public function __toString(): string {
+        return "hello";
+    }
+}
+
+class B extends A {
+    public function __toString(): never {
+        throw new \Exception('not supported');
+    }
+}
+
+try {
+    echo (string) (new B());
+} catch (Exception $e) {
+    // do nothing
+}
+
+echo "done";
+
+?>
+--EXPECT--
+done

--- a/Zend/tests/return_types/never_tostring.phpt
+++ b/Zend/tests/return_types/never_tostring.phpt
@@ -1,22 +1,22 @@
 --TEST--
-never type of __toString method
+never type of __toBool method
 --FILE--
 <?php
 
-class A implements Stringable {
-    public function __toString(): string {
-        return "hello";
+class A implements Falsifiable {
+    public function __toBool(): bool {
+        return true;
     }
 }
 
 class B extends A {
-    public function __toString(): never {
+    public function __toBool(): never {
         throw new \Exception('not supported');
     }
 }
 
 try {
-    echo (string) (new B());
+    echo (bool) (new B());
 } catch (Exception $e) {
     // do nothing
 }

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -178,6 +178,7 @@ struct _zend_class_entry {
 	zend_function *__call;
 	zend_function *__callstatic;
 	zend_function *__tostring;
+	zend_function *__tobool;
 	zend_function *__debugInfo;
 	zend_function *__serialize;
 	zend_function *__unserialize;

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -289,6 +289,7 @@ typedef struct _zend_fcall_info_cache {
 		class_container.__call = NULL;							\
 		class_container.__callstatic = NULL;					\
 		class_container.__tostring = NULL;						\
+		class_container.__tobool = NULL;						\
 		class_container.__get = NULL;							\
 		class_container.__set = NULL;							\
 		class_container.__unset = NULL;							\

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1848,6 +1848,7 @@ ZEND_API void zend_initialize_class_data(zend_class_entry *ce, bool nullify_hand
 		ce->__call = NULL;
 		ce->__callstatic = NULL;
 		ce->__tostring = NULL;
+		ce->__tobool = NULL;
 		ce->__serialize = NULL;
 		ce->__unserialize = NULL;
 		ce->__debugInfo = NULL;

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -145,6 +145,9 @@ static void do_inherit_parent_constructor(zend_class_entry *ce) /* {{{ */
 	if (EXPECTED(!ce->__tostring)) {
 		ce->__tostring = parent->__tostring;
 	}
+	if (EXPECTED(!ce->__tobool)) {
+		ce->__tobool = parent->__tobool;
+	}
 	if (EXPECTED(!ce->clone)) {
 		ce->clone = parent->clone;
 	}
@@ -2753,6 +2756,7 @@ static zend_class_entry *zend_lazy_class_load(zend_class_entry *pce)
 			zend_update_inherited_handler(__isset);
 			zend_update_inherited_handler(__unset);
 			zend_update_inherited_handler(__tostring);
+			zend_update_inherited_handler(__tobool);
 			zend_update_inherited_handler(__callstatic);
 			zend_update_inherited_handler(__debugInfo);
 			zend_update_inherited_handler(__serialize);
@@ -3015,6 +3019,8 @@ ZEND_API zend_class_entry *zend_do_link_class(zend_class_entry *ce, zend_string 
 			ce->interfaces[ce->num_interfaces - 1] = zend_ce_stringable;
 			do_interface_implementation(ce, zend_ce_stringable);
 		}
+
+		/* Believe the above (3010+) would hold tru for Falsifiable as well. */
 
 		zend_build_properties_info_table(ce);
 	} zend_catch {

--- a/Zend/zend_interfaces.stub.php
+++ b/Zend/zend_interfaces.stub.php
@@ -66,6 +66,11 @@ interface Stringable
     public function __toString(): string;
 }
 
+interface Falsifiable
+{
+    public function __toBool(): bool;
+}
+
 /**
  * @not-serializable
  */


### PR DESCRIPTION
[RFC on PHP Wiki](https://wiki.php.net/rfc/objects-can-be-falsifiable)

- [ ] Rebase will most likely be necessary at some point to remove changes to README from the commit history
- [ ] Research [Stringable](https://github.com/php/php-src/pull/5083/files) implementation
- [ ] Locate __toString() implementation in code
- [ ] Locate response to `empty()` function implementation
- [ ] Research [is_countable()](https://github.com/php/php-src/pull/3026) implementation as it might be helpful with handling `empty()`
- [ ] Demonstrate possible impact on static analysis tools
- [ ] Demonstrate impact on equality operators
- [ ] Any changes needed for Zend/zend_exceptions.c?

Disclaimer: I'm very green to internals development. I fancy myself a front-end and UX guy; so, this is a bit beyond my usual depth.